### PR TITLE
feat: add `CalendarObjectDeleted` and `CalendarObjectMovedToTrash` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,92 @@ Notification payload:
 }
 ```
 
+### Calendar Object Moved to Trash
+
+Fires whenever a calendar event is soft-deleted (moved to trash).
+
+Config name: `webhooks_calendar_object_moved_to_trash_url`
+
+Notification payload:
+```javascript
+{
+  calendarId: 30,
+  calendarData: {
+    id: '2',
+    uri: 'personal',
+    principaluri: 'principals/users/admin',
+    // [...]
+    '{http://apple.com/ns/ical/}calendar-order': '0',
+    '{http://apple.com/ns/ical/}calendar-color': '#795AAB',
+    '{http://nextcloud.com/ns}deleted-at': null,
+    '{http://nextcloud.com/ns}owner-displayname': 'admin'
+  },
+  shares: [],
+  objectData: {
+    id: '118',
+    uri: 'E855AF90-4A9B-4223-95E1-1FE700C4BDC0.ics',
+    lastmodified: '1660572955',
+    etag: '"79c725344d04a73b9bad1addee500bcf"',
+    calendarid: '30',
+    size: 748,
+    calendardata: 'BEGIN:VCALENDAR\r\n' +
+      'CALSCALE:GREGORIAN\r\n' +
+      'VERSION:2.0\r\n' +
+      'PRODID:-//IDN nextcloud.com//Calendar app 3.3.1//EN\r\n' +
+      'BEGIN:VEVENT\r\n' +
+      // [...] more data in iCal format
+      'END:VTIMEZONE\r\n' +
+      'END:VCALENDAR',
+    component: 'vevent',
+    classification: 0
+  },
+  eventType: 'OCA\\DAV\\Events\\CalendarObjectMovedToTrashEvent'
+}
+```
+
+### Calendar Object Deleted
+
+Fires whenever a calendar event is permanently deleted (i.e. deleted from the trashbin).
+
+Config name: `webhooks_calendar_object_deleted`
+
+Notification payload:
+```javascript
+{
+  calendarId: 30,
+  calendarData: {
+    id: '30',
+    uri: 'test',
+    principaluri: 'principals/users/admin',
+    // [...]
+    '{http://apple.com/ns/ical/}calendar-order': 0,
+    '{http://apple.com/ns/ical/}calendar-color': '#499AA2',
+    '{http://nextcloud.com/ns}deleted-at': null,
+    '{http://nextcloud.com/ns}owner-displayname': 'admin'
+  },
+  shares: [],
+  objectData: {
+    id: '118',
+    uri: 'E855AF90-4A9B-4223-95E1-1FE700C4BDC0-deleted.ics',
+    lastmodified: '1660572955',
+    etag: '"79c725344d04a73b9bad1addee500bcf"',
+    calendarid: '30',
+    size: 748,
+    calendardata: 'BEGIN:VCALENDAR\r\n' +
+      'CALSCALE:GREGORIAN\r\n' +
+      'VERSION:2.0\r\n' +
+      'PRODID:-//IDN nextcloud.com//Calendar app 3.3.1//EN\r\n' +
+      'BEGIN:VEVENT\r\n' +
+      // [...] more data in iCal format
+      'END:VTIMEZONE\r\n' +
+      'END:VCALENDAR',
+    component: 'vevent',
+    classification: 0
+  },
+  eventType: 'OCA\\DAV\\Events\\CalendarObjectDeletedEvent'
+}
+```
+
 ### Login Failed
 
 Fires whenever a login attempt with an existing username fails.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Outgoing webhooks can be triggered by either Nextcloud's internal events specifi
     <repository>https://github.com/kffl/nextcloud-webhooks</repository>
 	<screenshot>https://raw.githubusercontent.com/kffl/nextcloud-webhooks/master/screenshots/admin.png</screenshot>
     <dependencies>
-        <nextcloud min-version="20" max-version="24"/>
+        <nextcloud min-version="22" max-version="24"/>
     </dependencies>
 
     <settings>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
     
 Outgoing webhooks can be triggered by either Nextcloud's internal events specified in config.php or by Flow actions defined in the admin UI.
 ]]></description>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <licence>agpl</licence>
     <author mail="pawel@kuffel.io" >Paweł Kuffel</author>
     <documentation>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -27,6 +27,8 @@ namespace OCA\Webhooks\AppInfo;
 
 use OCA\Webhooks\Listeners\CalendarObjectCreatedListener;
 use OCA\Webhooks\Listeners\CalendarObjectUpdatedListener;
+use OCA\Webhooks\Listeners\CalendarObjectDeletedListener;
+use OCA\Webhooks\Listeners\CalendarObjectMovedToTrashListener;
 use OCA\Webhooks\Listeners\UserLiveStatusListener;
 use OCA\Webhooks\Listeners\LoginFailedListener;
 use OCA\Webhooks\Listeners\PasswordUpdatedListener;
@@ -38,6 +40,8 @@ use OCA\Webhooks\Listeners\UserLoggedInListener;
 use OCA\Webhooks\Listeners\UserLoggedOutListener;
 
 use OCA\DAV\Events\CalendarObjectCreatedEvent;
+use OCA\DAV\Events\CalendarObjectDeletedEvent;
+use OCA\DAV\Events\CalendarObjectMovedToTrashEvent;
 use OCA\DAV\Events\CalendarObjectUpdatedEvent;
 use OCA\Webhooks\Flow\RegisterFlowOperationsListener;
 use OCP\Authentication\Events\LoginFailedEvent; 
@@ -70,6 +74,8 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context):void {		
 		$context->registerEventListener(CalendarObjectCreatedEvent::class, CalendarObjectCreatedListener::class);
 		$context->registerEventListener(CalendarObjectUpdatedEvent::class, CalendarObjectUpdatedListener::class);
+		$context->registerEventListener(CalendarObjectDeletedEvent::class, CalendarObjectDeletedListener::class);
+		$context->registerEventListener(CalendarObjectMovedToTrashEvent::class, CalendarObjectMovedToTrashListener::class);
 		$context->registerEventListener(LoginFailedEvent::class, LoginFailedListener::class);
 		$context->registerEventListener(PasswordUpdatedEvent::class, PasswordUpdatedListener::class);
 		$context->registerEventListener(ShareCreatedEvent::class, ShareCreatedListener::class);
@@ -89,6 +95,8 @@ class Application extends App implements IBootstrap {
 		return array(
 			"Calendar Object Created" => CalendarObjectCreatedListener::CONFIG_NAME,
 			"Calendar Object Updated" => CalendarObjectUpdatedListener::CONFIG_NAME,
+			"Calendar Object Deleted" => CalendarObjectDeletedListener::CONFIG_NAME,
+			"Calendar Object Moved to Trash" => CalendarObjectMovedToTrashListener::CONFIG_NAME,
 			"Login Failed" => LoginFailedListener::CONFIG_NAME,
 			"Password Updated" => PasswordUpdatedListener::CONFIG_NAME,
 			"Share Created" => ShareCreatedListener::CONFIG_NAME,

--- a/lib/Listeners/CalendarObjectDeletedListener.php
+++ b/lib/Listeners/CalendarObjectDeletedListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2021 Paweł Kuffel <pawel@kuffel.io>
+ *
+ * @author Paweł Kuffel <pawel@kuffel.io>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Webhooks\Listeners;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCA\DAV\Events\CalendarObjectDeletedEvent;
+
+/**
+ * Class CalendarObjectUpdatedListener
+ *
+ * @package OCA\Webhooks\Listeners
+ */
+class CalendarObjectDeletedListener extends AbstractListener implements IEventListener {
+
+	public const CONFIG_NAME = "webhooks_calendar_object_deleted_url";
+
+	public function handleIncomingEvent(Event $event) {
+		if (!($event instanceOf CalendarObjectDeletedEvent)) {
+			return;
+		} 
+
+		return array(
+			"calendarId" => $event->getCalendarId(),
+			"calendarData" => $event->getCalendarData(),
+			"shares" => $event->getShares(),
+			"objectData" => $event->getObjectData(),
+		);
+	}
+}

--- a/lib/Listeners/CalendarObjectMovedToTrashListener.php
+++ b/lib/Listeners/CalendarObjectMovedToTrashListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2021 Paweł Kuffel <pawel@kuffel.io>
+ *
+ * @author Paweł Kuffel <pawel@kuffel.io>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Webhooks\Listeners;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCA\DAV\Events\CalendarObjectMovedToTrashEvent;
+
+/**
+ * Class CalendarObjectUpdatedListener
+ *
+ * @package OCA\Webhooks\Listeners
+ */
+class CalendarObjectMovedToTrashListener extends AbstractListener implements IEventListener {
+
+	public const CONFIG_NAME = "webhooks_calendar_object_moved_to_trash_url";
+
+	public function handleIncomingEvent(Event $event) {
+		if (!($event instanceOf CalendarObjectMovedToTrashEvent)) {
+			return;
+		} 
+
+		return array(
+			"calendarId" => $event->getCalendarId(),
+			"calendarData" => $event->getCalendarData(),
+			"shares" => $event->getShares(),
+			"objectData" => $event->getObjectData(),
+		);
+	}
+}


### PR DESCRIPTION
This PR adds `CalendarObjectDeleted` and `CalendarObjectMovedToTrash` events. Since the latter was added in v22, the required min Nextcloud version of the new release of this app was also bumped to 22.

Resolves #13 